### PR TITLE
remove the requirement that consumers depend on difference and newline-converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expectorate"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Adam H. Leventhal <ahl@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,52 +33,80 @@
 //! -Ten points for Gaston
 //! ```
 
-/// Compare the contents
-#[macro_export]
-macro_rules! assert_contents {
-    ($path:expr, $actual:expr) => {
-        use difference::Changeset;
-        use newline_converter::dos2unix;
-        use std::{env, fs, path::Path};
+use difference::Changeset;
+use newline_converter::dos2unix;
+use std::{env, fs, path::Path};
 
-        let ospath = Path::new($path);
-        let path = &ospath;
-        let var = env::var_os("EXPECTORATE");
-        let overwrite = match var.as_ref().map(|s| s.as_os_str().to_str()) {
-            Some(Some("overwrite")) => true,
-            _ => false,
+#[doc(hidden)]
+// This does the actual heavy lifting while the macro allows panics to appear
+// with the line numbers of the test invoking it. We don't intend consumers of
+// the crate to use this directly.
+pub fn do_assert_contents<P: AsRef<Path>>(
+    path: P,
+    actual: &str,
+) -> Result<(), (Option<String>, String)> {
+    let path = path.as_ref();
+    let var = env::var_os("EXPECTORATE");
+    let overwrite = match var.as_ref().map(|s| s.as_os_str().to_str()) {
+        Some(Some("overwrite")) => true,
+        _ => false,
+    };
+    let actual = dos2unix(actual);
+    if overwrite {
+        if let Err(e) = fs::write(path, actual.as_ref()) {
+            return Err((
+                None,
+                format!(
+                    "unable to write to {}: {}",
+                    path.display(),
+                    e.to_string()
+                ),
+            ));
+        }
+    } else {
+        // Treat non-existant files like an empty file.
+        let expected_s = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::NotFound => String::new(),
+                _ => panic!(
+                    "unable to read contents of {}: {}",
+                    path.display(),
+                    e.to_string()
+                ),
+            },
         };
+        let expected = dos2unix(&expected_s);
 
-        let actual = dos2unix($actual);
-
-        if overwrite {
-            if let Err(e) = fs::write(ospath, actual.as_ref()) {
-                panic!("unable to write to {}: {}", path.display(), e.to_string());
-            }
-        } else {
-            // Treat non-existant files like an empty file.
-            let expected_s = match fs::read_to_string(ospath) {
-                Ok(s) => s,
-                Err(e) => match e.kind() {
-                    std::io::ErrorKind::NotFound => String::new(),
-                    _ => panic!(
-                        "unable to read contents of {}: {}",
-                        path.display(),
-                        e.to_string()
-                    ),
-                },
-            };
-            let expected = dos2unix(&expected_s);
-
-            let changeset =
-                Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
-            if changeset.distance != 0 {
-                println!("{}", changeset);
-                panic!(
+        let changeset =
+            Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
+        if changeset.distance != 0 {
+            return Err((
+                Some(changeset.to_string()),
+                format!(
                     r#"assertion failed: string doesn't match the contents of file: "{}" see diffset above
                     set EXPECTORATE=overwrite if these changes are intentional"#,
                     path.display()
-                );
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Compare the contents of the file to the data provided
+#[macro_export]
+macro_rules! assert_contents {
+    ($path:expr, $actual:expr) => {
+        match $crate::do_assert_contents($path, $actual) {
+            Ok(_) => {}
+            Err((None, panicstr)) => {
+                panic!(panicstr)
+            }
+            Err((Some(info), panicstr)) => {
+                println!("{}", info);
+                panic!(panicstr);
             }
         }
     };


### PR DESCRIPTION
The new macro version is cool, but has some accidental external dependencies. This change wraps up those dependencies by instead exporting an undocumented function `do_assert_contents` that does all the heavy lifting.

I'm half tempted to add the function interface for compatibility with version 1.x, but the macro version really does seem preferable so I think we should guide people there.