### PR TITLE
Pretty print unified diff with 5 line before/after window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["test", "fixture"]
 categories = ["development-tools::testing"]
 
 [dependencies]
-difference = "2.0.0"
+similar = "2.1.0"
 newline-converter = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@
 //! -Ten points for Gaston
 //! ```
 
-use difference::Changeset;
 use newline_converter::dos2unix;
+use similar::{udiff::unified_diff, Algorithm};
 use std::{env, fs, path::Path};
 
 /// Compare the contents of the file to the string provided
@@ -69,9 +69,9 @@ pub fn assert_contents<P: AsRef<Path>>(path: P, actual: &str) {
         let expected = dos2unix(&expected_s);
 
         if expected != actual {
-            let changeset =
-                Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
-            println!("{}", changeset);
+            let diff =
+                unified_diff(Algorithm::Myers, &expected, &actual, 5, None);
+            println!("{}", diff);
             panic!(
                 r#"assertion failed: string doesn't match the contents of file: "{}" see diffset above
                 set EXPECTORATE=overwrite if these changes are intentional"#,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,13 @@ pub fn assert_contents<P: AsRef<Path>>(path: P, actual: &str) {
         let expected = dos2unix(&expected_s);
 
         if expected != actual {
-            let diff =
-                unified_diff(Algorithm::Myers, &expected, &actual, 5, None);
+            let diff = unified_diff(
+                Algorithm::Myers, // default algorithm used by git
+                &expected,
+                &actual,
+                5, // lines before and after
+                None,
+            );
             println!("{}", diff);
             panic!(
                 r#"assertion failed: string doesn't match the contents of file: "{}" see diffset above

--- a/tests/data_a2.txt
+++ b/tests/data_a2.txt
@@ -14,7 +14,7 @@ a aye
 eh.
 
 A eh?
-a a A
+this line changed
 a aye
 eh.
 

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -14,3 +14,10 @@ fn bad() {
     let actual = include_str!("data_a.txt");
     assert_contents("tests/data_b.txt", actual);
 }
+
+#[test]
+#[should_panic]
+fn one_line_change() {
+    let actual = include_str!("data_a.txt");
+    assert_contents("tests/data_a2.txt", actual);
+}


### PR DESCRIPTION
Closes #9

Tried and failed to make it work with `difference` and [`pretty_assertions`](https://docs.rs/pretty_assertions/0.6.1/pretty_assertions/). Found success with [Similar](https://insta.rs/similar/). Very clean.

This is already a net improvement as-is, but some possible improvements:

- use color
- increase window size to 10 or something
- tests could assert what gets printed to stdout instead of only checking for the panic

### one line difference

<img width="264" alt="Screen Shot 2022-03-18 at 4 37 22 PM" src="https://user-images.githubusercontent.com/3612203/159086283-4f95d24c-22ed-44e1-be22-2b9e383fe440.png">
 
### all lines difference

<img width="212" alt="Screen Shot 2022-03-18 at 4 37 33 PM" src="https://user-images.githubusercontent.com/3612203/159086308-530e7c89-7466-4b5d-b5b6-d93815623ca6.png">