### PR TITLE
Explicitly disallow overwriting in some cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,28 @@ use std::{env, fs, path::Path};
 /// Compare the contents of the file to the string provided
 #[track_caller]
 pub fn assert_contents<P: AsRef<Path>>(path: P, actual: &str) {
+    assert_contents_maybe_overwrite(path, actual, true)
+}
+
+/// Compare the contents of the file to the string provided but don't allow expectorate overwrite
+#[track_caller]
+pub fn assert_contents_without_overwrite<P: AsRef<Path>>(
+    path: P,
+    actual: &str,
+) {
+    assert_contents_maybe_overwrite(path, actual, false)
+}
+
+/// Compare the contents of the file to the string provided
+#[track_caller]
+fn assert_contents_maybe_overwrite<P: AsRef<Path>>(
+    path: P,
+    actual: &str,
+    allow_overwrite: bool,
+) {
     let path = path.as_ref();
     let var = env::var_os("EXPECTORATE");
-    let overwrite = match var.as_ref().map(|s| s.as_os_str().to_str()) {
+    let overwrite = allow_overwrite && match var.as_ref().map(|s| s.as_os_str().to_str()) {
         Some(Some("overwrite")) => true,
         _ => false,
     };


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/pull/885 we explicitly opted not to use the assert contents method because we [didn't want folks easily updating the file](https://github.com/oxidecomputer/omicron/blob/c1982248ef3d121af0cfad2d4af37be13cbc1b1b/nexus/tests/integration_tests/unauthorized_coverage.rs#L132-L135). While that's fine on the face of it, the error experience got objectively worse and has cost a non-trivial amount of debugging time. I'd put in a change to make the error message more friendly, but it broke [half the assumptions of the test](https://github.com/oxidecomputer/omicron/pull/1957/files#r1043965920). 

This PR sketches out a possible option where we have a method that explicitly doesn't perform overwriting. This is just a rough PoC, hoping to more generate conversation and figure out a direction. 
