### PR TITLE
use atomicwrites, avoid overwriting if file is the same

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,6 @@ jobs:
       with:
         toolchain: ${{ matrix.toolchain }}
     - name: Build
-      run: cargo build --tests --verbose
+      run: cargo build --tests --verbose ${{ matrix.feature_flags }}
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose ${{ matrix.feature_flags }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-latest]
         # 1.75 is the MSRV
         toolchain: ["1.75", stable]
         features: [all, default]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,12 +22,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12]
+        # 1.75 is the MSRV
+        toolchain: ["1.75", stable]
         features: [all, default]
         include:
           - features: all
             feature_flags: --all-features
     steps:
     - uses: actions/checkout@v3.5.0
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
     - name: Build
       run: cargo build --tests --verbose
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target/
+/target
 */target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "console"
@@ -33,7 +56,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -55,13 +78,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "expectorate"
 version = "1.1.0"
 dependencies = [
+ "atomicwrites",
  "console",
+ "filetime",
  "newline-converter",
  "predicates",
  "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -71,6 +125,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -90,9 +156,32 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
@@ -125,6 +214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "predicates"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,10 +273,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -181,12 +330,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -195,13 +371,29 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -211,10 +403,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -223,10 +427,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -235,13 +457,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "expectorate"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.75"
 license = "Apache-2.0"
 description = "Library for comparing output to file contents with simple updating"
 repository = "https://github.com/oxidecomputer/expectorate"
@@ -17,7 +18,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 predicates = ["dep:predicates"]
 
 [dependencies]
+atomicwrites = "0.4.4"
 console = "0.15.7"
 newline-converter = "0.3.0"
 predicates = { version = "3.0.4", optional = true }
 similar = "2.2.1"
+
+[dev-dependencies]
+filetime = "0.2.25"
+tempfile = "3.19.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/feature_predicates.rs
+++ b/src/feature_predicates.rs
@@ -36,7 +36,11 @@ impl Display for FilePredicate {
 
 impl Predicate<str> for FilePredicate {
     fn eval(&self, actual: &str) -> bool {
-        match crate::assert_contents_impl(&self.path, actual) {
+        match crate::assert_contents_impl(
+            &self.path,
+            actual,
+            crate::OverwriteMode::from_env(),
+        ) {
             Err(e) if self.panic => {
                 panic!("assertion failed: {e}")
             }

--- a/src/feature_predicates.rs
+++ b/src/feature_predicates.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{fmt::Display, path::PathBuf};
 

--- a/src/feature_predicates.rs
+++ b/src/feature_predicates.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2023-2025 Oxide Computer Company
 
 use std::{fmt::Display, path::PathBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,70 +52,146 @@ mod feature_predicates;
 #[cfg(feature = "predicates")]
 pub use feature_predicates::*;
 
+use atomicwrites::{AtomicFile, OverwriteBehavior};
 use console::Style;
 use newline_converter::dos2unix;
 use similar::{Algorithm, ChangeTag, TextDiff};
-use std::{env, ffi::OsStr, fs, path::Path};
+use std::{env, ffi::OsStr, fs, io::Write, path::Path};
 
 /// Compare the contents of the file to the string provided
 #[track_caller]
 pub fn assert_contents<P: AsRef<Path>>(path: P, actual: &str) {
-    if let Err(e) = assert_contents_impl(path, actual) {
+    if let Err(e) =
+        assert_contents_impl(path, actual, OverwriteMode::from_env())
+    {
         panic!("assertion failed: {e}")
     }
 }
 
-pub(crate) fn assert_contents_impl<P: AsRef<Path>>(path: P, actual: &str) -> Result<(), String> {
-    let path = path.as_ref();
-    let var = env::var_os("EXPECTORATE");
-    let overwrite = var.as_deref().and_then(OsStr::to_str) == Some("overwrite");
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OverwriteMode {
+    Check,
+    Overwrite,
+}
 
+impl OverwriteMode {
+    pub(crate) fn from_env() -> Self {
+        let var = env::var_os("EXPECTORATE");
+        if var.as_deref().and_then(OsStr::to_str) == Some("overwrite") {
+            OverwriteMode::Overwrite
+        } else {
+            OverwriteMode::Check
+        }
+    }
+}
+
+pub(crate) fn assert_contents_impl<P: AsRef<Path>>(
+    path: P,
+    actual: &str,
+    mode: OverwriteMode,
+) -> Result<(), String> {
+    let path = path.as_ref();
     let actual = dos2unix(actual);
 
-    if overwrite {
-        if let Err(e) = fs::write(path, actual.as_ref()) {
-            panic!("unable to write to {}: {}", path.display(), e);
-        }
-    } else {
-        // Treat a nonexistent file like an empty file.
-        let expected_s = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => match e.kind() {
-                std::io::ErrorKind::NotFound => String::new(),
-                _ => panic!("unable to read contents of {}: {}", path.display(), e),
-            },
-        };
-        let expected = dos2unix(&expected_s);
+    let current = match fs::read_to_string(path) {
+        Ok(s) => Some(s),
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::NotFound => None,
+            _ => panic!("unable to read contents of {}: {}", path.display(), e),
+        },
+    };
 
-        if expected != actual {
-            for hunk in TextDiff::configure()
-                .algorithm(Algorithm::Myers)
-                .diff_lines(&expected, &actual)
-                .unified_diff()
-                .context_radius(5)
-                .iter_hunks()
-            {
-                println!("{}", hunk.header());
-                for change in hunk.iter_changes() {
-                    let (marker, style) = match change.tag() {
-                        ChangeTag::Delete => ('-', Style::new().red()),
-                        ChangeTag::Insert => ('+', Style::new().green()),
-                        ChangeTag::Equal => (' ', Style::new()),
-                    };
-                    print!("{}", style.apply_to(marker).bold());
-                    print!("{}", style.apply_to(change));
-                    if change.missing_newline() {
-                        println!();
-                    }
+    match mode {
+        OverwriteMode::Overwrite => {
+            // Don't write the file if it's the same contents. This avoids mtime
+            // invalidation.
+            if current.as_deref() != Some(&actual) {
+                // There's no way to do a compare-and-set kind of operation on
+                // filesystems where you can say "only overwrite this file if the
+                // inode matches what was just read". The closest approximation is
+                // to disallow overwrites if the file doesn't exist.
+                let behavior = if current.is_some() {
+                    OverwriteBehavior::AllowOverwrite
+                } else {
+                    OverwriteBehavior::DisallowOverwrite
+                };
+                let f = AtomicFile::new(path, behavior);
+                let res = f.write(|f| {
+                    // We're writing the contents out in one call, so there's no
+                    // need to have a BufWriter wrapper.
+                    f.write(actual.as_bytes())
+                });
+                if let Err(e) = res {
+                    panic!("unable to write to {}: {}", path.display(), e);
                 }
             }
-            println!();
-            return Err(format!(
-                r#"string doesn't match the contents of file: "{}" see diffset above
+        }
+        OverwriteMode::Check => {
+            // Treat a nonexistent file like an empty file.
+            let expected_s = current.unwrap_or_default();
+            let expected = dos2unix(&expected_s);
+
+            if expected != actual {
+                for hunk in TextDiff::configure()
+                    .algorithm(Algorithm::Myers)
+                    .diff_lines(&expected, &actual)
+                    .unified_diff()
+                    .context_radius(5)
+                    .iter_hunks()
+                {
+                    println!("{}", hunk.header());
+                    for change in hunk.iter_changes() {
+                        let (marker, style) = match change.tag() {
+                            ChangeTag::Delete => ('-', Style::new().red()),
+                            ChangeTag::Insert => ('+', Style::new().green()),
+                            ChangeTag::Equal => (' ', Style::new()),
+                        };
+                        print!("{}", style.apply_to(marker).bold());
+                        print!("{}", style.apply_to(change));
+                        if change.missing_newline() {
+                            println!();
+                        }
+                    }
+                }
+                println!();
+                return Err(format!(
+                    r#"string doesn't match the contents of file: "{}" see diffset above
                 set EXPECTORATE=overwrite if these changes are intentional"#,
-                path.display()
-            ));
+                    path.display()
+                ));
+            }
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use filetime::{set_file_mtime, FileTime};
+    use tempfile::TempDir;
+
+    /// If EXPECTORATE=overwrite is set and the file is unchanged, ensure that
+    /// the mtime stays the same.
+    #[test]
+    fn overwite_same_mtime_doesnt_change() {
+        static CONTENTS: &str = "foo";
+        const MTIME: FileTime = FileTime::zero();
+
+        let dir = TempDir::with_prefix("expectorate-").unwrap();
+        let path = dir.path().join("my-file.txt");
+        fs::write(&path, CONTENTS).unwrap();
+
+        // Set the mtime to a fixed value.
+        set_file_mtime(&path, MTIME).unwrap();
+
+        // Overwrite the contents with the same value.
+        assert_contents_impl(&path, CONTENTS, OverwriteMode::Overwrite)
+            .unwrap();
+
+        let meta = fs::metadata(&path).unwrap();
+        let mtime2 = FileTime::from_last_modification_time(&meta);
+
+        assert_eq!(mtime2, MTIME, "mtime is zero");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2023-2025 Oxide Computer Company
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,10 @@ mod tests {
     #[test]
     fn overwite_same_mtime_doesnt_change() {
         static CONTENTS: &str = "foo";
-        const MTIME: FileTime = FileTime::zero();
+        // Setting the mtime to 1970-01-01 doesn't appear to work on Windows.
+        // Instead, set it to 2000-01-01. The exact time doesn't really matter
+        // here as much as having a fixed value that's in the past.`
+        const MTIME: FileTime = FileTime::from_unix_time(946684800, 0);
 
         let dir = TempDir::with_prefix("expectorate-").unwrap();
         let path = dir.path().join("my-file.txt");


### PR DESCRIPTION
Fix a couple of issues:

1. If some tests read from the same snapshots that others write to, they can see partially written files. Use atomicwrites to not encounter this issue. (In general, files in VCS repos should use atomic writes.)
2. If the file is the same, don't overwrite it. This avoids an mtime bump which can cause unnecessary cache invalidation issues.

Also add:

* a rust-version field (I picked 1.75 somewhat arbitrarily -- this avoids a lockfile bump)
* CI for the MSRV
* tests
* rustfmt.toml with 80 width

Fixes #22.